### PR TITLE
Implemented round manager system with round configuration and advancement handling

### DIFF
--- a/core/src/main/java/io/wasabi/urg/Roulette.java
+++ b/core/src/main/java/io/wasabi/urg/Roulette.java
@@ -7,12 +7,14 @@ import com.badlogic.gdx.utils.viewport.Viewport;
 
 import io.wasabi.urg.managers.FontManager;
 import io.wasabi.urg.managers.RendererManager;
+import io.wasabi.urg.managers.RoundManager;
 import io.wasabi.urg.screens.GameScreen;
 import io.wasabi.urg.state.RunState;
 
 public class Roulette extends Game {
     private static final Roulette INSTANCE = new Roulette();
     private final RunState runState = new RunState();
+    private final RoundManager roundManager = new RoundManager(runState);
 
     // Renderers
     private RendererManager rendererManager;
@@ -62,4 +64,5 @@ public class Roulette extends Game {
     }
 
     public RunState getRunState() { return runState; }
+    public RoundManager getRoundManager() { return roundManager; }
 }

--- a/core/src/main/java/io/wasabi/urg/elements/game/Ball.java
+++ b/core/src/main/java/io/wasabi/urg/elements/game/Ball.java
@@ -297,7 +297,7 @@ public class Ball extends GameObject {
         }
 
         Roulette.getInstance().getRunState().setLastTile(tile);
-        Roulette.getInstance().getRunState().triggerCardEffects("afterSpin");
+        Roulette.getInstance().getRoundManager().recordSpin();
     }
 
     private Tile getLandedTile() {

--- a/core/src/main/java/io/wasabi/urg/managers/QuotaCalculator.java
+++ b/core/src/main/java/io/wasabi/urg/managers/QuotaCalculator.java
@@ -1,0 +1,10 @@
+package io.wasabi.urg.managers;
+
+public class QuotaCalculator {
+
+    public static int calculate(int act, int round) {
+        // Todo: Implement a more complex formula based on act and round
+
+        return 10;
+    }
+}

--- a/core/src/main/java/io/wasabi/urg/managers/RoundConfig.java
+++ b/core/src/main/java/io/wasabi/urg/managers/RoundConfig.java
@@ -1,0 +1,25 @@
+package io.wasabi.urg.managers;
+
+public final class RoundConfig {
+    private final int act;
+    private final int round;
+    private final boolean bossRound;
+    private final int quota;
+    private final float quotaMult;
+    private final int spinsAllowed;
+
+    public RoundConfig(int act, int round, boolean bossRound, int quota, float quotaMult, int spinsAllowed) {
+        this.act = act;
+        this.round = round;
+        this.bossRound = bossRound;
+        this.quota = quota;
+        this.quotaMult = quotaMult;
+        this.spinsAllowed = spinsAllowed;
+    }
+
+    public int getAct() { return act; }
+    public int getRound() { return round; }
+    public boolean isBossRound() { return bossRound; }
+    public int getQuota() { return (int) (quota * quotaMult); }
+    public int getSpinsAllowed() { return spinsAllowed; }
+}

--- a/core/src/main/java/io/wasabi/urg/managers/RoundManager.java
+++ b/core/src/main/java/io/wasabi/urg/managers/RoundManager.java
@@ -1,0 +1,77 @@
+package io.wasabi.urg.managers;
+
+import io.wasabi.urg.state.RunState;
+
+public class RoundManager {
+    // Change as needed
+    private static final int SPINS_PER_ROUND = 5;
+    private static final int ROUNDS_PER_ACT = 5;
+    private static final int TOTAL_ACTS = 3;
+
+    private int act = 1;
+    private int round = 1;
+    private RoundConfig currentConfig;
+    private int spinsRemaining = 5;
+    private final RunState runState;
+
+    public RoundManager(RunState runState) {
+        this.runState = runState;
+        this.currentConfig = buildConfig();
+    }
+
+    private RoundConfig buildConfig() {
+        int quota = QuotaCalculator.calculate(act, round);
+
+        // Boss Round
+        if (round == ROUNDS_PER_ACT) {
+            return new RoundConfig(act, round, true, quota, 2f, spinsRemaining);
+        }
+
+        // Normal Round
+        return new RoundConfig(act, round, false, quota, 1f, spinsRemaining);
+    }
+
+    public void startRound() {
+        spinsRemaining = SPINS_PER_ROUND;
+        currentConfig = buildConfig();
+        runState.triggerCardEffects("roundStart");
+    }
+
+    public void recordSpin() {
+        spinsRemaining--;
+        runState.triggerCardEffects("afterSpin");
+
+        // Temp Debug
+        System.out.println("Act: " + act + ", Round: " + round + ", Quota: " + currentConfig.getQuota() + ", Chips: " + runState.getChips());
+        System.out.println("Spins remaining: " + spinsRemaining);
+
+        if (runState.getChips() >= currentConfig.getQuota()) {
+            System.out.println("winner");
+            advance();
+        } else if (spinsRemaining <= 0) {
+            System.out.println("loser");
+            gameOver();
+        }
+    }
+
+    public void advance() {
+        runState.triggerCardEffects("roundEnd");
+        runState.recordRoundBalance();
+
+        if (round == ROUNDS_PER_ACT) {
+            act++;
+            round = 1;
+        } else {
+            round++;
+        }
+    }
+
+    public void gameOver() {
+        // Handle game over logic here
+    }
+
+    public RoundConfig getCurrentConfig() { return currentConfig; }
+    public int getSpinsRemaining() { return spinsRemaining; }
+    public int getAct() { return act; }
+    public int getRound() { return round; }
+}


### PR DESCRIPTION
- Created round manager class
- The manager keeps track of current round, act and spins remaining
- Detect advancement on meeting quota or loss when running out of spins
- Create round configuration which can be customised depending on the round
- Uses temporary placeholder QuotaCalculator (to be implemented by Taiki)
- Round manager now handles, roundStart, afterSpin and roundEnd card effect triggers.
- Game over method created but not implemented.

Associated with issues:
#1 #14 