### PR TITLE
feat: update shop UI

### DIFF
--- a/core/src/main/java/io/wasabi/urg/managers/CardInputHandler.java
+++ b/core/src/main/java/io/wasabi/urg/managers/CardInputHandler.java
@@ -35,6 +35,7 @@ public class CardInputHandler extends InputAdapter {
     public boolean touchDown(int screenX, int screenY, int pointer, int button) {
         Vector2 world = screenToWorld(screenX, screenY);
 
+        Shop shop = GAME.getGameScreen().getShop();
         List<Card> cards = runState.getOwnedCards();
         for (int i = cards.size() - 1; i >= 0; i--) {
             Card card = cards.get(i);
@@ -42,6 +43,10 @@ public class CardInputHandler extends InputAdapter {
                 draggedCard = card;
                 draggedCard.setDragging(true);
                 dragOffset.set(world.x - card.getX(), world.y - card.getY());
+
+                if (shop.isVisible()) {
+                    shop.beginInventoryDrag();
+                }
                 return true;
             }
         }
@@ -100,7 +105,7 @@ public class CardInputHandler extends InputAdapter {
             }
         }
 
-        return true;
+        return false;
     }
 
     @Override

--- a/core/src/main/java/io/wasabi/urg/managers/CardInputHandler.java
+++ b/core/src/main/java/io/wasabi/urg/managers/CardInputHandler.java
@@ -45,7 +45,7 @@ public class CardInputHandler extends InputAdapter {
                 dragOffset.set(world.x - card.getX(), world.y - card.getY());
 
                 if (shop.isVisible()) {
-                    shop.beginInventoryDrag();
+                    shop.beginInventoryDrag(card.getSellPrice());
                 }
                 return true;
             }

--- a/core/src/main/java/io/wasabi/urg/managers/CharmInputHandler.java
+++ b/core/src/main/java/io/wasabi/urg/managers/CharmInputHandler.java
@@ -30,6 +30,7 @@ public class CharmInputHandler extends InputAdapter {
     public boolean touchDown(int screenX, int screenY, int pointer, int button) {
         Vector2 world = screenToWorld(screenX, screenY);
 
+        Shop shop = GAME.getGameScreen().getShop();
         List<AbstractCharm> charms = runState.getOwnedCharms();
         for (int i = charms.size() - 1; i >= 0; i--) {
             AbstractCharm charm = charms.get(i);
@@ -42,6 +43,10 @@ public class CharmInputHandler extends InputAdapter {
                     Roulette.getInstance().getGameScreen().getWheel().setShowConsumeZone(false);
                 } else {
                     Roulette.getInstance().getGameScreen().getWheel().setShowConsumeZone(true);
+                }
+
+                if (shop.isVisible()) {
+                    shop.beginInventoryDrag(charm.getSellPrice());
                 }
 
                 return true;

--- a/core/src/main/java/io/wasabi/urg/screens/GameScreen.java
+++ b/core/src/main/java/io/wasabi/urg/screens/GameScreen.java
@@ -8,15 +8,13 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
-import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.physics.box2d.World;
 import com.badlogic.gdx.utils.ScreenUtils;
 
@@ -34,7 +32,14 @@ import io.wasabi.urg.managers.CharmInputHandler;
 import io.wasabi.urg.managers.FontManager;
 import io.wasabi.urg.managers.RendererManager;
 import io.wasabi.urg.managers.SoundManager;
-import io.wasabi.urg.ui.*;
+import io.wasabi.urg.ui.CardLayout;
+import io.wasabi.urg.ui.CharmLayout;
+import io.wasabi.urg.ui.GameOver;
+import io.wasabi.urg.ui.QuotaTracker;
+import io.wasabi.urg.ui.RoundInfoPanel;
+import io.wasabi.urg.ui.RoundResult;
+import io.wasabi.urg.ui.Shop;
+import io.wasabi.urg.ui.Tooltip;
 
 
 public class GameScreen implements Screen {
@@ -116,11 +121,12 @@ public class GameScreen implements Screen {
         this.ball = new Ball(world, 6f, wheelCenter);
 
         this.roundResult = new RoundResult(shapeRenderer, spriteBatch);
-        this.shop = new Shop(shapeRenderer, spriteBatch, game.getViewport());
+        this.shop = new Shop(spriteBatch, game.getViewport());
         this.gameOver = new GameOver(shapeRenderer, spriteBatch, game.getViewport());
         this.inputMultiplexer.addProcessor(2, shop);
         this.quotaTracker = new QuotaTracker(shapeRenderer, spriteBatch, game.getRunState(), game.getRoundManager());
         this.roundInfoPanel = new RoundInfoPanel(-700f, 250f);
+        roundInfoPanel.updateRoundType();
     }
 
     public void spin() {
@@ -203,6 +209,12 @@ public class GameScreen implements Screen {
         gameState = GameState.SHOP;
 
         roundResult.hide();
+
+        roundInfoPanel.setRoundType("Shop");
+        roundInfoPanel.setRoundInfo("Enhance your run!", "Drag-n-drop items to the BUY/SELL squares");
+
+        roundInfoPanel.show();
+        quotaTracker.show();
         shop.show();
     }
 
@@ -213,10 +225,13 @@ public class GameScreen implements Screen {
         inputMultiplexer.addProcessor(1, charmInputHandler);
 
         shop.hide();
+
+        Roulette.getInstance().getRoundManager().startRound();
+
         roundInfoPanel.show();
         quotaTracker.show();
 
-        Roulette.getInstance().getRoundManager().startRound();
+        roundInfoPanel.updateRoundType();
 
         wheel.shiftIntoScreen();
     }

--- a/core/src/main/java/io/wasabi/urg/ui/QuotaTracker.java
+++ b/core/src/main/java/io/wasabi/urg/ui/QuotaTracker.java
@@ -4,9 +4,8 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
-import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.MathUtils;
-import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.math.Matrix4;
 
 import io.wasabi.urg.elements.betting.Bet;
 import io.wasabi.urg.managers.FontManager;
@@ -192,5 +191,5 @@ public final class QuotaTracker {
     }
 
     public void hide() { tween = new Tween(1f, BAR_X, OFFSCREEN_X, Tween.TweenStyle.QUAD, Tween.TweenDirection.IN); }
-    public void show() { tween = new Tween(1f, BAR_X, 22f, Tween.TweenStyle.QUAD, Tween.TweenDirection.OUT); }
+    public void show() { tween = new Tween(0.7f, BAR_X, 22f, Tween.TweenStyle.CIRCULAR, Tween.TweenDirection.OUT); }
 }

--- a/core/src/main/java/io/wasabi/urg/ui/RoundInfoPanel.java
+++ b/core/src/main/java/io/wasabi/urg/ui/RoundInfoPanel.java
@@ -1,5 +1,7 @@
 package io.wasabi.urg.ui;
 
+import java.util.List;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -18,8 +20,6 @@ import io.wasabi.urg.managers.RoundConfig;
 import io.wasabi.urg.managers.RoundManager;
 import io.wasabi.urg.state.RunState;
 import io.wasabi.urg.util.tweens.Tween;
-
-import java.util.List;
 
 public class RoundInfoPanel {
 
@@ -123,7 +123,7 @@ public class RoundInfoPanel {
     public void setBackingPadding(float padding) { this.backingPadding = padding; }
     public void setTicketIconSize(float size) { this.ticketIconSize = size; }
 
-    public void update(float delta) {
+    public void updateRoundType() {
         Boss boss = this.runState.getBoss();
         RoundConfig config = this.roundManager.getCurrentConfig();
 
@@ -134,7 +134,9 @@ public class RoundInfoPanel {
             setRoundType("Normal Round");
             setRoundInfo("A normal round of roulette.", "Reach the quota before you run out of spins.");
         }
+    }
 
+    public void update(float delta) {
         List<Bet> activeBets = this.runState.getActiveBets();
         int betSum = activeBets.stream().mapToInt(Bet::getAmount).sum();
         setBetAmount(betSum);

--- a/core/src/main/java/io/wasabi/urg/ui/RoundInfoPanel.java
+++ b/core/src/main/java/io/wasabi/urg/ui/RoundInfoPanel.java
@@ -345,5 +345,5 @@ public class RoundInfoPanel {
     }
 
     public void hide() { tween = new Tween(1f, x, OFFSCREEN_X, Tween.TweenStyle.QUAD, Tween.TweenDirection.IN); }
-    public void show() { tween = new Tween(1f, x, -700f, Tween.TweenStyle.QUAD, Tween.TweenDirection.OUT); }
+    public void show() { tween = new Tween(0.7f, x, -700f, Tween.TweenStyle.CIRCULAR, Tween.TweenDirection.OUT); }
 }

--- a/core/src/main/java/io/wasabi/urg/ui/Shop.java
+++ b/core/src/main/java/io/wasabi/urg/ui/Shop.java
@@ -84,8 +84,8 @@ public class Shop extends InputAdapter {
         drawCharmOffers();
         visible = true;
         continueRequested = false;
-        tween = new Tween(1f, OFFSCREEN_X, -95f, Tween.TweenStyle.QUAD, Tween.TweenDirection.OUT);
-        tweenY = new Tween(1f, OFFSCREEN_Y, 0, Tween.TweenStyle.QUAD, Tween.TweenDirection.OUT);
+        tween = new Tween(0.9f, OFFSCREEN_X, -95f, Tween.TweenStyle.CIRCULAR, Tween.TweenDirection.OUT);
+        tweenY = new Tween(0.7f, OFFSCREEN_Y, 0, Tween.TweenStyle.CIRCULAR, Tween.TweenDirection.OUT);
     }
 
     public void hide() {

--- a/core/src/main/java/io/wasabi/urg/ui/Shop.java
+++ b/core/src/main/java/io/wasabi/urg/ui/Shop.java
@@ -58,6 +58,25 @@ public class Shop extends InputAdapter {
     private final Rectangle buyBox = new Rectangle();
     private final Rectangle sellBox = new Rectangle();
 
+    private boolean rerollButtonHover = false;
+    private boolean rerollButtonDown = false;
+    private final Color rerollButtonColor = new Color(0.6f, 0.5f, 0.2f, 1);
+    private final Color rerollButtonHoverColor = new Color(0.4f, 0.3f, 0f, 1);
+    private final Color rerollButtonDownColor = new Color(0.61f, 0.51f, 0.21f, 1);
+
+    private boolean continueButtonHover = false;
+    private boolean continueButtonDown = false;
+    private final Color continueButtonColor = new Color(0.2f, 0.6f, 0.2f, 1);
+    private final Color continueButtonHoverColor = new Color(0f, 0.4f, 0f, 1);
+    private final Color continueButtonDownColor = new Color(0.21f, 0.61f, 0.21f, 1);
+
+    private final Color buyButtonColor = new Color(0.4f, 0.6f, 0.4f, 1);
+    private final Color buyButtonHoverColor = new Color(0.3f, 0.7f, 0.3f, 1);
+
+    private boolean draggingInventory = false;
+    private final Color sellButtonColor = new Color(0.6f, 0.4f, 0.4f, 1);
+    private final Color sellButtonHoverColor = new Color(0.7f, 0.3f, 0.3f, 1);
+
     private Tween tween;
     private Tween tweenY;
     private float x = OFFSCREEN_X;
@@ -114,31 +133,6 @@ public class Shop extends InputAdapter {
         layoutOffers(left);
         layoutCharmOffers(left);
 
-        // shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
-        // shapeRenderer.setColor(0.10f, 0.10f, 0.13f, 1f);
-        // shapeRenderer.rect(CENTER_Y, bottom - 300f, WIDTH, HEIGHT + 300f);
-        // shapeRenderer.setColor(0.18f, 0.18f, 0.22f, 1f);
-        // shapeRenderer.rect(CENTER_Y, bottom + HEIGHT - 90f, WIDTH, 90f);
-
-        // shapeRenderer.setColor(0.22f, 0.22f, 0.27f, 1f);
-        // for (Card card : offers) {
-        //     shapeRenderer.rect(card.getX() - 12f, card.getY() - 42f, 120f, 182f);
-        // }
-        // shapeRenderer.setColor(0.27f, 0.22f, 0.27f, 1f);
-        // for (AbstractCharm charm : charmOffers) {
-        //     shapeRenderer.rect(charm.getX() - 8f, charm.getY() - 8f, charm.getWidth() + 16f, charm.getHeight() + 16f);
-        // }
-
-        // shapeRenderer.setColor(0.22f, 0.50f, 0.28f, 1f);
-        // shapeRenderer.rect(buyBox.x, buyBox.y, buyBox.width, buyBox.height);
-        // shapeRenderer.setColor(0.55f, 0.25f, 0.25f, 1f);
-        // shapeRenderer.rect(sellBox.x, sellBox.y, sellBox.width, sellBox.height);
-        // shapeRenderer.setColor(0.35f, 0.35f, 0.65f, 1f);
-        // shapeRenderer.rect(rerollButton.x, rerollButton.y, rerollButton.width, rerollButton.height);
-        // shapeRenderer.setColor(0.25f, 0.60f, 0.30f, 1f);
-        // shapeRenderer.rect(continueButton.x, continueButton.y, continueButton.width, continueButton.height);
-        // shapeRenderer.end();
-
         spriteBatch.begin();
         spriteBatch.setTransformMatrix(new com.badlogic.gdx.math.Matrix4().setToTranslation(0, 0, 0));
 
@@ -154,25 +148,30 @@ public class Shop extends InputAdapter {
         float boxPadding = 3f;
         spriteBatch.setColor(1, 1, 1, 1);
         patch.draw(spriteBatch, buyBox.x - boxPadding/2, buyBox.y - boxPadding/2, buyBox.width + boxPadding, buyBox.height + boxPadding);
-        spriteBatch.setColor(0.4f, 0.6f, 0.4f, 1);
+        spriteBatch.setColor((draggedCard != null || draggedCharm != null) ? buyButtonHoverColor : buyButtonColor);
         patch.draw(spriteBatch, buyBox.x, buyBox.y, buyBox.width, buyBox.height);
 
         // sell box
         spriteBatch.setColor(1, 1, 1, 1);
         patch.draw(spriteBatch, sellBox.x - boxPadding / 2, sellBox.y - boxPadding / 2, sellBox.width + boxPadding, sellBox.height + boxPadding);
-        spriteBatch.setColor(0.6f, 0.4f, 0.4f, 1);
+        spriteBatch.setColor(draggingInventory ? sellButtonHoverColor : sellButtonColor);
         patch.draw(spriteBatch, sellBox.x, sellBox.y, sellBox.width, sellBox.height);
 
         // continue
         spriteBatch.setColor(1, 1, 1, 1);
         patch.draw(spriteBatch, continueButton.x - boxPadding / 2, continueButton.y - boxPadding / 2, continueButton.width + boxPadding, continueButton.height + boxPadding);
-        spriteBatch.setColor(0.2f, 0.6f, 0.2f, 1);
+        if (continueButtonDown && continueButtonHover) {
+            spriteBatch.setColor(continueButtonDownColor);
+        } else spriteBatch.setColor(continueButtonHover ? continueButtonHoverColor : continueButtonColor);
         patch.draw(spriteBatch, continueButton.x, continueButton.y, continueButton.width, continueButton.height);
 
         // REROLL
         spriteBatch.setColor(1, 1, 1, 1);
         patch.draw(spriteBatch, rerollButton.x - boxPadding / 2, rerollButton.y - boxPadding / 2, rerollButton.width + boxPadding, rerollButton.height + boxPadding);
-        spriteBatch.setColor(0.6f, 0.5f, 0.2f, 1);
+        if (rerollButtonDown && rerollButtonHover) {
+            spriteBatch.setColor(rerollButtonDownColor);
+        } else spriteBatch.setColor(rerollButtonHover ? rerollButtonHoverColor : rerollButtonColor);
+
         patch.draw(spriteBatch, rerollButton.x, rerollButton.y, rerollButton.width, rerollButton.height);
 
         spriteBatch.setColor(1, 1, 1, 1);
@@ -249,6 +248,17 @@ public class Shop extends InputAdapter {
             }
         }
 
+        rerollButtonDown = rerollButton.contains(world);
+        continueButtonDown = continueButton.contains(world);
+
+        return false;
+    }
+
+    @Override
+    public boolean mouseMoved(int screenX, int screenY) {
+        Vector2 world = screenToWorld(screenX, screenY);
+        rerollButtonHover = rerollButton.contains(world);
+        continueButtonHover = continueButton.contains(world);
         return false;
     }
 
@@ -256,6 +266,9 @@ public class Shop extends InputAdapter {
     public boolean touchDragged(int screenX, int screenY, int pointer) {
         if (!visible) return false;
         Vector2 world = screenToWorld(screenX, screenY);
+
+        rerollButtonHover = rerollButton.contains(world);
+        continueButtonHover = continueButton.contains(world);
 
         if (draggedCard != null) {
             draggedCard.setPosition(world.x - dragOffset.x, world.y - dragOffset.y);
@@ -293,6 +306,9 @@ public class Shop extends InputAdapter {
         if (!visible) return false;
         Vector2 world = screenToWorld(screenX, screenY);
 
+        rerollButtonDown = false;
+        continueButtonDown = false;
+
         if (draggedCard != null) {
             finishCardDrag(world);
             return true;
@@ -326,9 +342,14 @@ public class Shop extends InputAdapter {
         dragOffset.set(world.x - charm.getX(), world.y - charm.getY());
     }
 
+    public void beginInventoryDrag() {
+        draggingInventory = true;
+    }
+
     public void finishInventoryCardDrag(int x, int y, Card card) {
         Vector2 world = screenToWorld(x, y);
         draggedCard = card;
+        draggingInventory = false;
         draggingOffer = false;
         finishCardDrag(world);
     }
@@ -336,6 +357,7 @@ public class Shop extends InputAdapter {
     public void finishInventoryCharmDrag(int x, int y, AbstractCharm charm) {
         Vector2 world = screenToWorld(x, y);
         draggedCharm = charm;
+        draggingInventory = false;
         draggingCharmOffer = false;
         finishCharmDrag(world);
     }

--- a/core/src/main/java/io/wasabi/urg/ui/Shop.java
+++ b/core/src/main/java/io/wasabi/urg/ui/Shop.java
@@ -77,6 +77,8 @@ public class Shop extends InputAdapter {
     private final Color sellButtonColor = new Color(0.6f, 0.4f, 0.4f, 1);
     private final Color sellButtonHoverColor = new Color(0.7f, 0.3f, 0.3f, 1);
 
+    private int currentSellPrice = 0;
+
     private Tween tween;
     private Tween tweenY;
     private float x = OFFSCREEN_X;
@@ -182,8 +184,12 @@ public class Shop extends InputAdapter {
         layout.setText(FONT, "BUY", Color.WHITE, buyBox.width, Align.center, false);
         FONT.draw(spriteBatch, "BUY", buyBox.x, buyBox.y + buyBox.height / 2f + layout.height / 2f, buyBox.width, Align.center, false);
 
-        layout.setText(FONT, "SELL", Color.WHITE, buyBox.width, Align.center, false);
-        FONT.draw(spriteBatch, "SELL", sellBox.x, sellBox.y + sellBox.height / 2f + layout.height / 2f, sellBox.width, Align.center, false);
+        String sellText = "SELL";
+        if (currentSellPrice > 0) {
+            sellText = "SELL - $" + currentSellPrice;
+        }
+        layout.setText(FONT, sellText, Color.WHITE, buyBox.width, Align.center, false);
+        FONT.draw(spriteBatch, sellText, sellBox.x, sellBox.y + sellBox.height / 2f + layout.height / 2f, sellBox.width, Align.center, false);
 
         String rerollText = "REROLL - " + REROLL_PRICE;
         layout.setText(FONT, rerollText, Color.WHITE, rerollButton.width, Align.center, false);
@@ -308,6 +314,7 @@ public class Shop extends InputAdapter {
 
         rerollButtonDown = false;
         continueButtonDown = false;
+        currentSellPrice = 0;
 
         if (draggedCard != null) {
             finishCardDrag(world);
@@ -342,8 +349,9 @@ public class Shop extends InputAdapter {
         dragOffset.set(world.x - charm.getX(), world.y - charm.getY());
     }
 
-    public void beginInventoryDrag() {
+    public void beginInventoryDrag(int price) {
         draggingInventory = true;
+        currentSellPrice = price;
     }
 
     public void finishInventoryCardDrag(int x, int y, Card card) {
@@ -351,6 +359,7 @@ public class Shop extends InputAdapter {
         draggedCard = card;
         draggingInventory = false;
         draggingOffer = false;
+        currentSellPrice = 0;
         finishCardDrag(world);
     }
 
@@ -359,6 +368,7 @@ public class Shop extends InputAdapter {
         draggedCharm = charm;
         draggingInventory = false;
         draggingCharmOffer = false;
+        currentSellPrice = 0;
         finishCharmDrag(world);
     }
 

--- a/core/src/main/java/io/wasabi/urg/ui/Shop.java
+++ b/core/src/main/java/io/wasabi/urg/ui/Shop.java
@@ -3,10 +3,14 @@ package io.wasabi.urg.ui;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.GlyphLayout;
+import com.badlogic.gdx.graphics.g2d.NinePatch;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
@@ -21,28 +25,33 @@ import io.wasabi.urg.state.RunState;
 import io.wasabi.urg.util.tweens.Tween;
 
 public class Shop extends InputAdapter {
-    private static final float WIDTH = 1200f;
-    private static final float HEIGHT = 650f;
-    private static final float CENTER_X = -WIDTH / 2f;
+    private static final float WIDTH = 680f;
+    private static final float HEIGHT = 900f;
+    private static final float CENTER_Y = -HEIGHT / 2f;
+    private static final float OFFSCREEN_X = -1500f;
     private static final float OFFSCREEN_Y = -1500f;
+
     private static final int OFFER_COUNT = 4;
     private static final int CHARM_OFFER_COUNT = 3;
     private static final int REROLL_PRICE = 5;
-    private static final float OFFER_START_X = -300f;
-    private static final float OFFER_SPACING = 160f;
-    private static final float CHARM_OFFER_START_X = -260f;
-    private static final float CHARM_OFFER_SPACING = 160f;
+
+    private static final float OFFER_START_Y = 155f;
+    private static final float OFFER_TARGET_WIDTH = 620f;
+    private static final float CHARM_OFFER_START_Y = OFFER_START_Y - 250f;
     // Shop appearance settings — adjust these to resize the price text/button.
     private static final float PRICE_FONT_SCALE = 0.6f;
-    private static final float REROLL_BUTTON_WIDTH = 260f;
-    private static final BitmapFont FONT = FontManager.getInstance().getFontByName("Placeholder");
 
-    private final ShapeRenderer shapeRenderer;
+    private static final BitmapFont FONT = FontManager.getInstance().getFontByName("Placeholder");
+    private static final BitmapFont FONT_64PX = FontManager.getInstance().getFontByName("Terminus64PXBold");
+
+    private static final Texture PATCH_TEXTURE = new Texture(Gdx.files.internal("ui/CorneredPatch.png"));
+
     private final SpriteBatch spriteBatch;
     private final Viewport viewport;
     private final RunState runState;
     private final List<Card> offers = new ArrayList<>();
     private final List<AbstractCharm> charmOffers = new ArrayList<>();
+    private final NinePatch patch = new NinePatch(PATCH_TEXTURE, 10, 10, 10, 10);
 
     private final Rectangle continueButton = new Rectangle();
     private final Rectangle rerollButton = new Rectangle();
@@ -50,6 +59,8 @@ public class Shop extends InputAdapter {
     private final Rectangle sellBox = new Rectangle();
 
     private Tween tween;
+    private Tween tweenY;
+    private float x = OFFSCREEN_X;
     private float y = OFFSCREEN_Y;
     private boolean visible;
     private boolean continueRequested;
@@ -60,8 +71,7 @@ public class Shop extends InputAdapter {
     private boolean draggingCharmOffer;
     private final Vector2 dragOffset = new Vector2();
 
-    public Shop(ShapeRenderer shapeRenderer, SpriteBatch spriteBatch, Viewport viewport) {
-        this.shapeRenderer = shapeRenderer;
+    public Shop(SpriteBatch spriteBatch, Viewport viewport) {
         this.spriteBatch = spriteBatch;
         this.viewport = viewport;
         this.runState = Roulette.getInstance().getRunState();
@@ -74,7 +84,8 @@ public class Shop extends InputAdapter {
         drawCharmOffers();
         visible = true;
         continueRequested = false;
-        tween = new Tween(1f, OFFSCREEN_Y, 0f, Tween.TweenStyle.QUAD, Tween.TweenDirection.OUT);
+        tween = new Tween(1f, OFFSCREEN_X, -95f, Tween.TweenStyle.QUAD, Tween.TweenDirection.OUT);
+        tweenY = new Tween(1f, OFFSCREEN_Y, 0, Tween.TweenStyle.QUAD, Tween.TweenDirection.OUT);
     }
 
     public void hide() {
@@ -83,55 +94,104 @@ public class Shop extends InputAdapter {
         draggedCard = null;
         draggedCharm = null;
         //visible = false; // stop sudden disappearance of shop when tweening out
-        tween = new Tween(1f, y, OFFSCREEN_Y, Tween.TweenStyle.QUAD, Tween.TweenDirection.IN);
+        tween = new Tween(1f, x, OFFSCREEN_X, Tween.TweenStyle.QUAD, Tween.TweenDirection.IN);
+        tweenY = new Tween(1f, y, OFFSCREEN_Y, Tween.TweenStyle.QUAD, Tween.TweenDirection.IN);
     }
 
     public void update(float delta) {
         if (visible && tween != null && !tween.isComplete()) {
-            y = tween.update(delta);
+            x = tween.update(delta);
+            y = tweenY.update(delta);
         }
     }
 
     public void render() {
         if (!visible) return;
 
+        float left = x - WIDTH / 2f;
         float bottom = y - HEIGHT / 2f;
-        layoutControls(bottom);
-        layoutOffers(bottom);
-        layoutCharmOffers(bottom);
+        layoutControls(bottom, left);
+        layoutOffers(left);
+        layoutCharmOffers(left);
 
-        shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
-        shapeRenderer.setColor(0.10f, 0.10f, 0.13f, 1f);
-        shapeRenderer.rect(CENTER_X, bottom - 300f, WIDTH, HEIGHT + 300f);
-        shapeRenderer.setColor(0.18f, 0.18f, 0.22f, 1f);
-        shapeRenderer.rect(CENTER_X, bottom + HEIGHT - 90f, WIDTH, 90f);
+        // shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
+        // shapeRenderer.setColor(0.10f, 0.10f, 0.13f, 1f);
+        // shapeRenderer.rect(CENTER_Y, bottom - 300f, WIDTH, HEIGHT + 300f);
+        // shapeRenderer.setColor(0.18f, 0.18f, 0.22f, 1f);
+        // shapeRenderer.rect(CENTER_Y, bottom + HEIGHT - 90f, WIDTH, 90f);
 
-        shapeRenderer.setColor(0.22f, 0.22f, 0.27f, 1f);
-        for (Card card : offers) {
-            shapeRenderer.rect(card.getX() - 12f, card.getY() - 42f, 120f, 182f);
-        }
-        shapeRenderer.setColor(0.27f, 0.22f, 0.27f, 1f);
-        for (AbstractCharm charm : charmOffers) {
-            shapeRenderer.rect(charm.getX() - 8f, charm.getY() - 8f, charm.getWidth() + 16f, charm.getHeight() + 16f);
-        }
+        // shapeRenderer.setColor(0.22f, 0.22f, 0.27f, 1f);
+        // for (Card card : offers) {
+        //     shapeRenderer.rect(card.getX() - 12f, card.getY() - 42f, 120f, 182f);
+        // }
+        // shapeRenderer.setColor(0.27f, 0.22f, 0.27f, 1f);
+        // for (AbstractCharm charm : charmOffers) {
+        //     shapeRenderer.rect(charm.getX() - 8f, charm.getY() - 8f, charm.getWidth() + 16f, charm.getHeight() + 16f);
+        // }
 
-        shapeRenderer.setColor(0.22f, 0.50f, 0.28f, 1f);
-        shapeRenderer.rect(buyBox.x, buyBox.y, buyBox.width, buyBox.height);
-        shapeRenderer.setColor(0.55f, 0.25f, 0.25f, 1f);
-        shapeRenderer.rect(sellBox.x, sellBox.y, sellBox.width, sellBox.height);
-        shapeRenderer.setColor(0.35f, 0.35f, 0.65f, 1f);
-        shapeRenderer.rect(rerollButton.x, rerollButton.y, rerollButton.width, rerollButton.height);
-        shapeRenderer.setColor(0.25f, 0.60f, 0.30f, 1f);
-        shapeRenderer.rect(continueButton.x, continueButton.y, continueButton.width, continueButton.height);
-        shapeRenderer.end();
+        // shapeRenderer.setColor(0.22f, 0.50f, 0.28f, 1f);
+        // shapeRenderer.rect(buyBox.x, buyBox.y, buyBox.width, buyBox.height);
+        // shapeRenderer.setColor(0.55f, 0.25f, 0.25f, 1f);
+        // shapeRenderer.rect(sellBox.x, sellBox.y, sellBox.width, sellBox.height);
+        // shapeRenderer.setColor(0.35f, 0.35f, 0.65f, 1f);
+        // shapeRenderer.rect(rerollButton.x, rerollButton.y, rerollButton.width, rerollButton.height);
+        // shapeRenderer.setColor(0.25f, 0.60f, 0.30f, 1f);
+        // shapeRenderer.rect(continueButton.x, continueButton.y, continueButton.width, continueButton.height);
+        // shapeRenderer.end();
 
         spriteBatch.begin();
         spriteBatch.setTransformMatrix(new com.badlogic.gdx.math.Matrix4().setToTranslation(0, 0, 0));
-        FONT.draw(spriteBatch, "SHOP", -30f, bottom + HEIGHT - 30f);
-        FONT.draw(spriteBatch, "BUY", buyBox.x + 55f, buyBox.y + 85f);
-        FONT.draw(spriteBatch, "SELL", sellBox.x + 50f, sellBox.y + 85f);
-        FONT.draw(spriteBatch, "REROLL - " + REROLL_PRICE, rerollButton.x + 30f, rerollButton.y + 43f);
-        FONT.draw(spriteBatch, "CONTINUE", continueButton.x + 75f, continueButton.y + 43f);
+
+        // white outline
+        spriteBatch.setColor(1, 1, 1, 1);
+        patch.draw(spriteBatch, left - 4f, CENTER_Y, WIDTH + 8, HEIGHT);
+
+        // black inner
+        spriteBatch.setColor(0.10f, 0.10f, 0.13f, 1f);
+        patch.draw(spriteBatch, left, CENTER_Y + 2.5f, WIDTH, HEIGHT - 5);
+
+        // buy box
+        float boxPadding = 3f;
+        spriteBatch.setColor(1, 1, 1, 1);
+        patch.draw(spriteBatch, buyBox.x - boxPadding/2, buyBox.y - boxPadding/2, buyBox.width + boxPadding, buyBox.height + boxPadding);
+        spriteBatch.setColor(0.4f, 0.6f, 0.4f, 1);
+        patch.draw(spriteBatch, buyBox.x, buyBox.y, buyBox.width, buyBox.height);
+
+        // sell box
+        spriteBatch.setColor(1, 1, 1, 1);
+        patch.draw(spriteBatch, sellBox.x - boxPadding / 2, sellBox.y - boxPadding / 2, sellBox.width + boxPadding, sellBox.height + boxPadding);
+        spriteBatch.setColor(0.6f, 0.4f, 0.4f, 1);
+        patch.draw(spriteBatch, sellBox.x, sellBox.y, sellBox.width, sellBox.height);
+
+        // continue
+        spriteBatch.setColor(1, 1, 1, 1);
+        patch.draw(spriteBatch, continueButton.x - boxPadding / 2, continueButton.y - boxPadding / 2, continueButton.width + boxPadding, continueButton.height + boxPadding);
+        spriteBatch.setColor(0.2f, 0.6f, 0.2f, 1);
+        patch.draw(spriteBatch, continueButton.x, continueButton.y, continueButton.width, continueButton.height);
+
+        // REROLL
+        spriteBatch.setColor(1, 1, 1, 1);
+        patch.draw(spriteBatch, rerollButton.x - boxPadding / 2, rerollButton.y - boxPadding / 2, rerollButton.width + boxPadding, rerollButton.height + boxPadding);
+        spriteBatch.setColor(0.6f, 0.5f, 0.2f, 1);
+        patch.draw(spriteBatch, rerollButton.x, rerollButton.y, rerollButton.width, rerollButton.height);
+
+        spriteBatch.setColor(1, 1, 1, 1);
+
+        FONT_64PX.draw(spriteBatch, "SHOP", left + 30f, HEIGHT / 2 - 30f);
+
+        GlyphLayout layout = new GlyphLayout();
+        layout.setText(FONT, "BUY", Color.WHITE, buyBox.width, Align.center, false);
+        FONT.draw(spriteBatch, "BUY", buyBox.x, buyBox.y + buyBox.height / 2f + layout.height / 2f, buyBox.width, Align.center, false);
+
+        layout.setText(FONT, "SELL", Color.WHITE, buyBox.width, Align.center, false);
+        FONT.draw(spriteBatch, "SELL", sellBox.x, sellBox.y + sellBox.height / 2f + layout.height / 2f, sellBox.width, Align.center, false);
+
+        String rerollText = "REROLL - " + REROLL_PRICE;
+        layout.setText(FONT, rerollText, Color.WHITE, rerollButton.width, Align.center, false);
+        FONT.draw(spriteBatch, rerollText, rerollButton.x, rerollButton.y + rerollButton.height / 2f + layout.height / 2f, rerollButton.width, Align.center, false);
+
+        layout.setText(FONT, "CONTINUE", Color.WHITE, continueButton.width, Align.center, false);
+        FONT.draw(spriteBatch, "CONTINUE", continueButton.x, continueButton.y + continueButton.height / 2f + layout.height / 2f, continueButton.width, Align.center, false);
 
         for (Card card : offers) {
             if (card == draggedCard) continue;
@@ -393,28 +453,36 @@ public class Shop extends InputAdapter {
         charmOffers.clear();
     }
 
-    private void layoutControls(float bottom) {
-        buyBox.set(560f, bottom + 245f, 160f, 150f);
-        sellBox.set(-720f, bottom + 245f, 160f, 150f);
-        rerollButton.set(-290f, bottom - 75f, REROLL_BUTTON_WIDTH, 65f);
-        continueButton.set(30f, bottom - 75f, 240f, 65f);
+    private void layoutControls(float bottom, float left) {
+        buyBox.set(280f, bottom + 150f, 225f, 300f);
+        sellBox.set(550f, bottom + 150f, 225f, 300f);
+        rerollButton.set(left + WIDTH / 2 - OFFER_TARGET_WIDTH / 2, -HEIGHT / 2f + 30f, OFFER_TARGET_WIDTH, 65f);
+        continueButton.set(280f, bottom + 30f, 495f, 65f);
     }
 
-    private void layoutOffers(float bottom) {
+    private void layoutOffers(float left) {
+        int size = OFFER_COUNT; // offers.size();
+        float spacing = (OFFER_TARGET_WIDTH - (size * 96f)) / size;
+        float targetX = spacing / 2 + left + WIDTH / 2 - OFFER_TARGET_WIDTH / 2;
         for (int i = 0; i < offers.size(); i++) {
             Card card = offers.get(i);
             if (!card.isDragging()) {
-                card.setPosition(OFFER_START_X + i * OFFER_SPACING, bottom + 380f);
+                card.setPosition(targetX, OFFER_START_Y);
             }
+            targetX += spacing + card.getWidth();
         }
     }
 
-    private void layoutCharmOffers(float bottom) {
+    private void layoutCharmOffers(float left) {
+        int size = CHARM_OFFER_COUNT; // offers.size();
+        float spacing = (OFFER_TARGET_WIDTH - (size * 64f)) / size;
+        float targetX = spacing / 2 + left + WIDTH / 2 - OFFER_TARGET_WIDTH / 2;
         for (int i = 0; i < charmOffers.size(); i++) {
             AbstractCharm charm = charmOffers.get(i);
             if (!charm.isDragging()) {
-                charm.setPosition(CHARM_OFFER_START_X + i * CHARM_OFFER_SPACING, bottom + 170f);
+                charm.setPosition(targetX, CHARM_OFFER_START_Y);
             }
+            targetX += spacing + charm.getWidth();
         }
     }
 

--- a/core/src/main/java/io/wasabi/urg/util/tweens/Tween.java
+++ b/core/src/main/java/io/wasabi/urg/util/tweens/Tween.java
@@ -60,7 +60,7 @@ public class Tween {
         time += delta;
         float alpha = formula.get(time / duration);
 
-        if (alpha >= 0.99f) {
+        if (time >= duration) {
             alpha = 1;
             complete = true;
         }

--- a/core/src/main/java/io/wasabi/urg/util/tweens/Tween.java
+++ b/core/src/main/java/io/wasabi/urg/util/tweens/Tween.java
@@ -3,13 +3,16 @@ package io.wasabi.urg.util.tweens;
 import java.lang.reflect.InvocationTargetException;
 import java.util.EnumMap;
 
+import io.wasabi.urg.util.tweens.formulae.BackOut;
+import io.wasabi.urg.util.tweens.formulae.CircularOut;
+import io.wasabi.urg.util.tweens.formulae.Linear;
 import io.wasabi.urg.util.tweens.formulae.QuadIn;
 import io.wasabi.urg.util.tweens.formulae.QuadInOut;
 import io.wasabi.urg.util.tweens.formulae.QuadOut;
 
 public class Tween {
     public enum TweenStyle {
-        QUAD,
+        LINEAR, QUAD, CIRCULAR, BACK
     }
     public enum TweenDirection {
         IN, OUT, INOUT
@@ -17,11 +20,33 @@ public class Tween {
 
     private static final EnumMap<TweenStyle, EnumMap<TweenDirection, Class<? extends TweenFormula>>> TWEEN_CLASSES
     = new EnumMap<TweenStyle, EnumMap<TweenDirection, Class<? extends TweenFormula>>>(TweenStyle.class){{
-        put(TweenStyle.QUAD, new EnumMap<TweenDirection, Class<? extends TweenFormula>>(TweenDirection.class) {{
-            put(TweenDirection.IN, QuadIn.class);
-            put(TweenDirection.OUT, QuadOut.class);
-            put(TweenDirection.INOUT, QuadInOut.class);
-        }});
+        put(TweenStyle.LINEAR, new EnumMap<TweenDirection, Class<? extends TweenFormula>>(TweenDirection.class) {
+            {
+                put(TweenDirection.IN, Linear.class);
+                put(TweenDirection.OUT, Linear.class);
+                put(TweenDirection.INOUT, Linear.class);
+            }
+        });
+
+        put(TweenStyle.QUAD, new EnumMap<TweenDirection, Class<? extends TweenFormula>>(TweenDirection.class) {
+            {
+                put(TweenDirection.IN, QuadIn.class);
+                put(TweenDirection.OUT, QuadOut.class);
+                put(TweenDirection.INOUT, QuadInOut.class);
+            }
+        });
+
+        put(TweenStyle.CIRCULAR, new EnumMap<TweenDirection, Class<? extends TweenFormula>>(TweenDirection.class) {
+            {
+                put(TweenDirection.OUT, CircularOut.class);
+            }
+        });
+
+        put(TweenStyle.BACK, new EnumMap<TweenDirection, Class<? extends TweenFormula>>(TweenDirection.class) {
+            {
+                put(TweenDirection.OUT, BackOut.class);
+            }
+        });
     }};
 
     private float duration;

--- a/core/src/main/java/io/wasabi/urg/util/tweens/formulae/BackOut.java
+++ b/core/src/main/java/io/wasabi/urg/util/tweens/formulae/BackOut.java
@@ -1,0 +1,13 @@
+package io.wasabi.urg.util.tweens.formulae;
+
+import io.wasabi.urg.util.tweens.TweenFormula;
+
+public class BackOut implements TweenFormula {
+    @Override
+    public float get(float x) {
+        float c1 = 1.70158f;
+        float c3 = c1 + 1;
+
+        return (float) (1 + c3 * Math.pow(x - 1, 3) + c1 * Math.pow(x - 1, 2));
+    }
+}

--- a/core/src/main/java/io/wasabi/urg/util/tweens/formulae/CircularOut.java
+++ b/core/src/main/java/io/wasabi/urg/util/tweens/formulae/CircularOut.java
@@ -1,0 +1,10 @@
+package io.wasabi.urg.util.tweens.formulae;
+
+import io.wasabi.urg.util.tweens.TweenFormula;
+
+public class CircularOut implements TweenFormula {
+    @Override
+    public float get(float x) {
+        return (float) Math.sqrt(1 - Math.pow(x - 1, 2));
+    }
+}

--- a/core/src/main/java/io/wasabi/urg/util/tweens/formulae/Linear.java
+++ b/core/src/main/java/io/wasabi/urg/util/tweens/formulae/Linear.java
@@ -1,0 +1,10 @@
+package io.wasabi.urg.util.tweens.formulae;
+
+import io.wasabi.urg.util.tweens.TweenFormula;
+
+public class Linear implements TweenFormula {
+    @Override
+    public float get(float x) {
+        return x;
+    }
+}


### PR DESCRIPTION
Update shop UI to use new patches.
- Round display now stays on the left side so you can see your tickets.
- The round instead displays a special "shop" round.
- Reroll & continue buttons have hover and on click effects.
- Buy and sell regions glow when you can drag the current object onto them.

Addresses #26 

<img width="1582" height="878" alt="image" src="https://github.com/user-attachments/assets/59348a15-ac1f-440c-9d1f-503c06658791" />
