### PR TITLE
fix round start cards bugging out with tile changes

### DIFF
--- a/core/src/main/java/io/wasabi/urg/elements/card/BlackCard.java
+++ b/core/src/main/java/io/wasabi/urg/elements/card/BlackCard.java
@@ -1,11 +1,7 @@
 package io.wasabi.urg.elements.card;
-import java.util.List;
-
-import io.wasabi.urg.Roulette;
 import io.wasabi.urg.elements.game.Tile;
 
 public class BlackCard extends Card {
-
     public BlackCard() {
         super(Rarity.COMMON);
         this.price = 4;
@@ -15,13 +11,12 @@ public class BlackCard extends Card {
     }
 
     @Override
-    public void roundStartEffect() {
-        triggerDisplay();
-        List<Tile> tiles = Roulette.getInstance().getGameScreen().getWheel().getTiles();
-        for (Tile tile : tiles) {
-            if (tile.getType().isBlack()) {
-                tile.setBetMultiplier(tile.getBetMultiplier() * 1.5f);
-            }
+    public float getPayoutMultiplier(Tile winningTile, int totalStaked, int chipBalance) {
+        if (winningTile.isBlack()) {
+            triggerDisplay();
+            return 1.5f;
+        } else {
+            return 1.0f;
         }
     }
 }

--- a/core/src/main/java/io/wasabi/urg/elements/card/GreenCard.java
+++ b/core/src/main/java/io/wasabi/urg/elements/card/GreenCard.java
@@ -1,8 +1,5 @@
 package io.wasabi.urg.elements.card;
 
-import java.util.List;
-
-import io.wasabi.urg.Roulette;
 import io.wasabi.urg.elements.game.Tile;
 
 public class GreenCard extends Card {
@@ -16,13 +13,12 @@ public class GreenCard extends Card {
     }
 
     @Override
-    public void roundStartEffect() {
-        triggerDisplay();
-        List<Tile> tiles = Roulette.getInstance().getGameScreen().getWheel().getTiles();
-        for (Tile tile : tiles) {
-            if (tile.getType().isGreen()) {
-                tile.setBetMultiplier(tile.getBetMultiplier() * 3f);
-            }
+    public float getPayoutMultiplier(Tile winningTile, int totalStaked, int chipBalance) {
+        if (winningTile.isGreen()) {
+            triggerDisplay();
+            return 3f;
+        } else {
+            return 1.0f;
         }
     }
 }

--- a/core/src/main/java/io/wasabi/urg/elements/card/OddCard.java
+++ b/core/src/main/java/io/wasabi/urg/elements/card/OddCard.java
@@ -16,13 +16,12 @@ public class OddCard extends Card {
     }
 
     @Override
-    public void roundStartEffect() {
-        triggerDisplay();
-        List<Tile> tiles = Roulette.getInstance().getGameScreen().getWheel().getTiles();
-        for (Tile tile : tiles) {
-            if (tile.getNumber() % 2 != 0) {
-                tile.setBetMultiplier(tile.getBetMultiplier() * 1.5f);
-            }
+    public float getPayoutMultiplier(Tile winningTile, int totalStaked, int chipBalance) {
+        if (winningTile.getNumber() % 2 != 0) {
+            triggerDisplay();
+            return 1.5f;
+        } else {
+            return 1.0f;
         }
     }
 }


### PR DESCRIPTION
Affects green card, black card and odd card:
- They now use `getPayoutMultiplier` instead of modifying tiles on round start
- This means they now respond to tile changes mid-round, fixing the problem

Closes #102 